### PR TITLE
Always use t3dn_bip

### DIFF
--- a/Brush_Manager.py
+++ b/Brush_Manager.py
@@ -4699,6 +4699,7 @@ def unregister():
     preview_brushes_coll.clear()
 
     previews.remove(t3dn_brush_coll)
+    previews.remove(t3dn_brush_fav_coll)
 
     try:
         bpy.app.handlers.load_post.remove(brush_manager_on_file_load)


### PR DESCRIPTION
I was snooping around to see how you did the integration, and noticed a resource warning in the console after shutting down Blender, which was caused because t3dn_brush_fav_coll wasn't being removed on unregister.

t3dn_bip is a drop-in replacement for bpy.utils.previews, so you don't need to do this double maintenance.
Functions which didn't do anything with t3dn_bip enabled were removed; this includes the undo_pre, which feels weird but oh well.
I don't understand your code as well as you do, so I probably missed some things, but I didn't get errors in my testing at least.

If you want to make use of some or all of these changes, feel free to.
If you don't, that's cool too (though definitely do the thing from the first commit).